### PR TITLE
Ensure properties are always computed after a minute

### DIFF
--- a/src/sunsetcalculatorcomponent.cpp
+++ b/src/sunsetcalculatorcomponent.cpp
@@ -77,7 +77,6 @@ namespace nap
 		{
 			mPreviousSunset = mCurrentSunset;
 			mCurrentSunrise = mNextSunrise;
-
 			mNextSunrise = calculateNextSunrise(now);
 			mSunset->setCurrentDate(now.getYear(), static_cast<int>(now.getMonth()), now.getDayInTheMonth());
 			mCurrentSunset = mSunset->calcSunset();
@@ -86,13 +85,9 @@ namespace nap
 		mCurrentSunsetHours = std::chrono::duration_cast<std::chrono::hours>(std::chrono::minutes(static_cast<int>(mCurrentSunset) + mMinutesOffsetTimeSunsettingDown)).count();
 		mCurrentSunsetMinutes = static_cast<int>(mCurrentSunset) % 60;
 
-		std::string minutes_logged = std::to_string((static_cast<int>(mCurrentSunrise) % 60));
-		if (minutes_logged.size() < 2) minutes_logged.insert(0,1,'0');
-
-		Logger::info("SunsetCalculatorComponentInstance::calculateCurrentSunsetState sunrise at :	%d:%s", static_cast<int>(mCurrentSunrise / 60), minutes_logged.c_str());
-		minutes_logged = std::to_string(mCurrentSunsetMinutes);
-		if (minutes_logged.size() < 2) minutes_logged.insert(0, 1, '0');
-		Logger::info("SunsetCalculatorComponentInstance::calculateCurrentSunsetState sunset at  :	%d:%s", mCurrentSunsetHours, minutes_logged.c_str());
+		int minutes_logged = static_cast<int>(mCurrentSunrise) % 60;
+		Logger::info("SunsetCalculatorComponentInstance::calculateCurrentSunsetState sunrise at: %.2d:%.2d", static_cast<int>(mCurrentSunrise / 60), minutes_logged);
+		Logger::info("SunsetCalculatorComponentInstance::calculateCurrentSunsetState sunset at:	%.2d:%.2d", mCurrentSunsetHours, mCurrentSunsetMinutes);
 
 		int h = now.getHour();
 		int m = now.getMinute();
@@ -125,7 +120,6 @@ namespace nap
 		auto time_passed_since_midnight = static_cast<double> (h * 60 + m);
 
 		mSunIsCurrentlyUp = true;
-
 		bool sun_up_in_the_sky = true;
 		if (time_passed_since_midnight < mCurrentSunrise || time_passed_since_midnight > mCurrentSunset)
 			sun_up_in_the_sky = false;

--- a/src/sunsetcalculatorcomponent.h
+++ b/src/sunsetcalculatorcomponent.h
@@ -8,6 +8,7 @@
 #include <nap/datetime.h>
 #include <nap/timer.h>
 #include <nap/signalslot.h>
+#include <mathutils.h>
 
 // Forward declare thirdparty-sunset
 class SunSet;
@@ -129,7 +130,6 @@ namespace nap
 		double mPreviousSunset = -1;					///< Yesterday's sunset time in minutes from midnight
 		double mNextSunrise = -1;						///< Tomorrow's sunrise time in minutes from midnight  
 
-
 		int mCurrentSunsetHours;						///< Today's sunset hour component (0-23)  
 		int mCurrentSunsetMinutes;						///< Today's sunset minute component (0-59)  
 		int mMinutesOffsetTimeSunsettingDown;			///< Additional offset (in minutes) after sunset until sun is completely down  : 1h extra to the time of the starting of the sun setting down --> the time the night is dark
@@ -137,11 +137,10 @@ namespace nap
 		float mCurrentPropSun = -1;						///< Sun's progress proportion (0.0-1.0): daytime progress when sun is up, nighttime progress when sun is down
 		int mTimeUntilNextSunchange = -1;				///< Current time in minutes until the sun is goin down, or setting up				
 		bool mSunIsCurrentlyUp;							///< Current daylight status (true = sun is above horizon)  
-
-		long mDeltaUntilNextCalculation = 10;			///< Time remaining (s) until next sunset/sunrise calculation  
+		long mDeltaUntilNextCalculation = 0;			///< Time remaining (s) until next sunset/sunrise calculation  
 
 		nap::SystemTimer mDeltaCalculationTimer;        ///< Timer tracking interval until next required calculation (at next sunset. Settings this to 10s so to not retrigger the calculation of the sunset until mDeltaUntilNextCalculation is properly set inside calculateCurrentSunsetState
-
 		std::unique_ptr<SunSet> mSunset = nullptr;		///< unique ptr to the sunset class
+		nap::SystemTimeStamp mCalcStamp;
 	};
 }


### PR DESCRIPTION
This change ensures that properties are always recomputed after a minute has passed, even when the component isn't evaluated every second. 