### PR TITLE
Simplify

### DIFF
--- a/demo/sunsetexample/data/objects.json
+++ b/demo/sunsetexample/data/objects.json
@@ -128,25 +128,6 @@
             }
         },
         {
-            "Type": "nap::ParameterGUI",
-            "mID": "ParameterGUI",
-            "Serializable": true,
-            "Group": "SunsetGUI"
-        },
-        {
-            "Type": "nap::ParameterGroup",
-            "mID": "Parameters",
-            "Parameters": [],
-            "Groups": [
-                {
-                    "Type": "nap::ParameterGroup",
-                    "mID": "SunsetGUI",
-                    "Parameters": [],
-                    "Groups": []
-                }
-            ]
-        },
-        {
             "Type": "nap::RenderWindow",
             "mID": "Window",
             "Borderless": false,

--- a/demo/sunsetexample/src/sunsetexampleapp.cpp
+++ b/demo/sunsetexample/src/sunsetexampleapp.cpp
@@ -84,15 +84,11 @@ namespace nap
 		ImGui::TextColored(is_up ? theme.mHighlightColor2 : theme.mHighlightColor4, "The sun is: %s", is_up ? "Up" : "Down");
 		ImGui::TextColored(theme.mHighlightColor1, "Sunrise: %s", sunset.getSunRise().toString().c_str());
 		ImGui::TextColored(theme.mHighlightColor3, "Sunset:  %s", sunset.getSunSet().toString().c_str());
-
-		//ImGui::TextColored(theme.mHighlightColor1, "%s course percentage in the %s = %f", is_up ? "Sun" : "Moon", is_up ? "sky" : "night", sunsetCalculatorComponentInstance.getProp());
-		//ImGui::TextColored(theme.mHighlightColor3, "Time until next sun course change (%s) : %i minutes", is_up ? "sunset" : "sunrise", sunsetCalculatorComponentInstance.getTimeUntilNextSunCourseChange());
-
 		ImGui::Text(utility::stringFormat("Framerate: %.02f", getCore().getFramerate()).c_str());
 		ImGui::End();
 	}
-	
-	
+
+
 	// Render app
 	void SunsetExampleApp::render()
 	{
@@ -132,14 +128,14 @@ namespace nap
 		// Proceed to next frame
 		mRenderService->endFrame();
 	}
-	
+
 
 	void SunsetExampleApp::windowMessageReceived(WindowEventPtr windowEvent)
 	{
 		mRenderService->addEvent(std::move(windowEvent));
 	}
-	
-	
+
+
 	void SunsetExampleApp::inputMessageReceived(InputEventPtr inputEvent)
 	{
 		if (inputEvent->get_type().is_derived_from(RTTI_OF(nap::KeyPressEvent)))
@@ -157,7 +153,7 @@ namespace nap
 		mInputService->addEvent(std::move(inputEvent));
 	}
 
-	
+
 	int SunsetExampleApp::shutdown()
 	{
 		return 0;

--- a/demo/sunsetexample/src/sunsetexampleapp.cpp
+++ b/demo/sunsetexample/src/sunsetexampleapp.cpp
@@ -75,7 +75,7 @@ namespace nap
 		mGuiService->selectWindow(mRenderWindow);
 
 		// Draw some gui elements
-		ImGui::Begin("Controls");
+		ImGui::Begin("Sunset");
 
 		// Display some extra info
 		bool is_up = sunset.isUp();
@@ -84,6 +84,7 @@ namespace nap
 		ImGui::TextColored(is_up ? theme.mHighlightColor2 : theme.mHighlightColor4, "The sun is: %s", is_up ? "Up" : "Down");
 		ImGui::TextColored(theme.mHighlightColor1, "Sunrise: %s", sunset.getSunRise().toString().c_str());
 		ImGui::TextColored(theme.mHighlightColor3, "Sunset:  %s", sunset.getSunSet().toString().c_str());
+		ImGui::Text("lat: %.2f, lon: %.2f", sunset.getLatitude(), sunset.getLongitude());
 		ImGui::Text(utility::stringFormat("Framerate: %.02f", getCore().getFramerate()).c_str());
 		ImGui::End();
 	}

--- a/demo/sunsetexample/src/sunsetexampleapp.cpp
+++ b/demo/sunsetexample/src/sunsetexampleapp.cpp
@@ -16,7 +16,7 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::SunsetExampleApp)
 	RTTI_CONSTRUCTOR(nap::Core&)
 RTTI_END_CLASS
 
-namespace nap 
+namespace nap
 {
 	/**
 	 * Initialize all the resources and instances used for drawing
@@ -61,29 +61,32 @@ namespace nap
 		// All done!
 		return true;
 	}
-	
-	
+
+
 	// Update app
 	void SunsetExampleApp::update(double deltaTime)
 	{
 		// Use a default input router to forward input events (recursively) to all input components in the default scene
 		nap::DefaultInputRouter input_router(true);
 		mInputService->processWindowEvents(*mRenderWindow, input_router, { &mScene->getRootEntity() });
-		auto& sunsetCalculatorComponentInstance = mSunsetEntity->getComponent<SunsetCalculatorComponentInstance>();
+		auto& sunset = mSunsetEntity->getComponent<SunsetCalculatorComponentInstance>();
 
 		// Select GUI window
 		mGuiService->selectWindow(mRenderWindow);
-		
+
 		// Draw some gui elements
 		ImGui::Begin("Controls");
 
 		// Display some extra info
-		bool is_up = sunsetCalculatorComponentInstance.isUp();
+		bool is_up = sunset.isUp();
 		const auto& theme = mGuiService->getPalette();
 		ImGui::Text(getCurrentDateTime().toString().c_str());
 		ImGui::TextColored(is_up ? theme.mHighlightColor2 : theme.mHighlightColor4, "The sun is: %s", is_up ? "Up" : "Down");
-		ImGui::TextColored(theme.mHighlightColor1, "%s course percentage in the %s = %f", is_up ? "Sun" : "Moon", is_up ? "sky" : "night", sunsetCalculatorComponentInstance.getProp());
-		ImGui::TextColored(theme.mHighlightColor3, "Time until next sun course change (%s) : %i minutes", is_up ? "sunset" : "sunrise", sunsetCalculatorComponentInstance.getTimeUntilNextSunCourseChange());
+		ImGui::TextColored(theme.mHighlightColor1, "Sunrise: %s", sunset.getSunRise().toString().c_str());
+		ImGui::TextColored(theme.mHighlightColor3, "Sunset:  %s", sunset.getSunSet().toString().c_str());
+
+		//ImGui::TextColored(theme.mHighlightColor1, "%s course percentage in the %s = %f", is_up ? "Sun" : "Moon", is_up ? "sky" : "night", sunsetCalculatorComponentInstance.getProp());
+		//ImGui::TextColored(theme.mHighlightColor3, "Time until next sun course change (%s) : %i minutes", is_up ? "sunset" : "sunrise", sunsetCalculatorComponentInstance.getTimeUntilNextSunCourseChange());
 
 		ImGui::Text(utility::stringFormat("Framerate: %.02f", getCore().getFramerate()).c_str());
 		ImGui::End();

--- a/src/sunsetcalculatorcomponent.cpp
+++ b/src/sunsetcalculatorcomponent.cpp
@@ -19,7 +19,9 @@ RTTI_END_ENUM
 RTTI_BEGIN_CLASS(nap::SunsetCalculatorComponent)
 	RTTI_PROPERTY("Latitude", &nap::SunsetCalculatorComponent::mLatitude, nap::rtti::EPropertyMetaData::Default, "Latitude of the location we want to know the sunrise and sundown of")
 	RTTI_PROPERTY("Longitude", &nap::SunsetCalculatorComponent::mLongitude, nap::rtti::EPropertyMetaData::Default, "Longitude of the location we want to know the sunrise and sundown of")
-	RTTI_PROPERTY("TimeZone", &nap::SunsetCalculatorComponent::mTimezone, nap::rtti::EPropertyMetaData::Default, "Timezone at Longitude")
+	RTTI_PROPERTY("TimeZone", &nap::SunsetCalculatorComponent::mTimezone, nap::rtti::EPropertyMetaData::Default, "Timezone at Longitude excluding daylight saving")
+	RTTI_PROPERTY("SunriseOffset", &nap::SunsetCalculatorComponent::mSunriseOffset, nap::rtti::EPropertyMetaData::Default, "Sunrise offset in minutes")
+	RTTI_PROPERTY("SunsetOffset", &nap::SunsetCalculatorComponent::mSunsetOffset, nap::rtti::EPropertyMetaData::Default, "Sunrise offset in minutes")
 RTTI_END_CLASS
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::SunsetCalculatorComponentInstance)
@@ -46,6 +48,8 @@ namespace nap
 		mTimezone = resource->mTimezone;
 		mLongitude = resource->mLongitude;
 		mLatitude = resource->mLatitude;
+		mSunriseOffset = resource->mSunriseOffset;
+		mSunsetOffset = resource->mSunsetOffset;
 
 		// Compute
 		update(0.0);
@@ -73,12 +77,12 @@ namespace nap
 
 			// Compute sunrise
 			static constexpr double mms = 60.0 * 1000.0;
-			double sunrise = mModel->calcSunrise();
+			double sunrise = mModel->calcSunrise() + mSunriseOffset;
 			mSunRiseStamp = null_time + Milliseconds(static_cast<int64>(sunrise * mms));
 			mSunRise = DateTime(mSunRiseStamp, DateTime::ConversionMode::Local);
 
 			// Compute sunset
-			double sunset = mModel->calcSunset();
+			double sunset = mModel->calcSunset() + mSunsetOffset;
 			mSunSetStamp = null_time + Milliseconds(static_cast<int64>(sunset * mms));
 			mSunset = DateTime(mSunSetStamp, DateTime::ConversionMode::Local);
 

--- a/src/sunsetcalculatorcomponent.cpp
+++ b/src/sunsetcalculatorcomponent.cpp
@@ -48,7 +48,7 @@ namespace nap
 		mLatitude = resource->mLatitude;
 
 		// Initialize model
-		mModel->setPosition(resource->mLatitude, resource->mLongitude, resource->mTimezone );
+		mModel->setPosition(mLatitude, mLongitude, mTimezone);
 
 		// Compute
 		update(0.0);

--- a/src/sunsetcalculatorcomponent.h
+++ b/src/sunsetcalculatorcomponent.h
@@ -19,6 +19,7 @@ namespace nap
 
 	/**
 	 * Calculates local sunset and sunrise for a given lat and longitude.
+	 * Listen to the 'mSunStateChanged, 'mSunUp' or 'mSunDown' signals to receive sunrise and sunset events.
 	 */
     class NAPAPI SunsetCalculatorComponent: public Component
     {
@@ -35,10 +36,11 @@ namespace nap
 
 
 	/**
-	 * Calculates local sunset and sunrise for a given lat and longitude, including offsets
+	 * Calculates **local** sunset and sunrise for a given lat and longitude, including offsets.
 	 * Listen to 'mSunStateChanged, 'mSunUp' or 'mSunDown' signals to receive sunrise and sunset events.
-	 * Note that this component uses the system local time, it does not figure out the timezone
-	 * for the given lon and latitude.
+	 *
+	 * Note that this component uses the systems local time to check if the sun is up or down,
+	 * not the time deducted from the given lon and latitude -> which it cannot do.
 	 */
 	class NAPAPI SunsetCalculatorComponentInstance : public ComponentInstance
 	{

--- a/src/sunsetcalculatorcomponent.h
+++ b/src/sunsetcalculatorcomponent.h
@@ -26,11 +26,11 @@ namespace nap
 		DECLARE_COMPONENT(SunsetCalculatorComponent, SunsetCalculatorComponentInstance)
 
 		public:
-
-			// Geographic coordinates and timezone for calculating sun position
-			double mLatitude = 0;					///<  Property: 'latitude' set to use 0	(Greenwich)	->(nul island)
-			double mLongitude = 0;					///<  Property: 'longitude' set to use 0(equator)	->(nul island)
-			int mTimezone = 1;						///<  Property: 'timezone' set to use 2 (Europe's timezone)
+			double mLatitude = 0;					///< Property: 'Latitude' set to use 0	(Greenwich)	->(nul island)
+			double mLongitude = 0;					///< Property: 'Longitude' set to use 0(equator)	->(nul island)
+			int mTimezone = 1;						///< Property: 'Timezone' timezone, excluding daylight savings
+    		double mSunriseOffset = 0.0;			///< Property: 'SunriseOffset' sunrise offset in minutes
+    		double mSunsetOffset = 0.0;				///< Property: 'SunsetOffset' sunset offset in minutes
     };
 
 
@@ -121,10 +121,12 @@ namespace nap
 		EDay mDay = EDay::Unknown;						///< current day
 
 		SystemTimeStamp mSunRiseStamp;					///< Sunrise timestamp
-		DateTime mSunRise;								///< Sunrise date-time
+		DateTime mSunRise;								///< Sunrise date-time=
+		double mSunriseOffset = 0.0;					///< Sunrise offset in minutes
 
 		SystemTimeStamp mSunSetStamp;					///< Sunset timestamp
 		DateTime mSunset;								///< Sunset date-time
+		double mSunsetOffset = 0.0;						///< Sunset offset in minutes
 
 		int mTimezone = 0;								///< Location timezone
 		double mLatitude = 0;							///< Location latitude

--- a/src/sunsetcalculatorcomponent.h
+++ b/src/sunsetcalculatorcomponent.h
@@ -18,7 +18,7 @@ namespace nap
 	class SunsetCalculatorComponentInstance;
 
 	/**
-	 * Calculates sunset and sunrise for a given lat and longitude
+	 * Calculates local sunset and sunrise for a given lat and longitude.
 	 */
     class NAPAPI SunsetCalculatorComponent: public Component
     {
@@ -35,7 +35,10 @@ namespace nap
 
 
 	/**
-	 * Calculates sunset and sunrise for a given lat and longitude
+	 * Calculates local sunset and sunrise for a given lat and longitude, including offsets
+	 * Listen to 'mSunStateChanged, 'mSunUp' or 'mSunDown' signals to receive sunrise and sunset events.
+	 * Note that this component uses the system local time, it does not figure out the timezone
+	 * for the given lon and latitude.
 	 */
 	class NAPAPI SunsetCalculatorComponentInstance : public ComponentInstance
 	{

--- a/src/sunsetcalculatorcomponent.h
+++ b/src/sunsetcalculatorcomponent.h
@@ -30,7 +30,7 @@ namespace nap
 			// Geographic coordinates and timezone for calculating sun position
 			double mLatitude = 0;					///<  Property: 'latitude' set to use 0	(Greenwich)	->(nul island)
 			double mLongitude = 0;					///<  Property: 'longitude' set to use 0(equator)	->(nul island)
-			int mTimezone = 2;						///<  Property: 'timezone' set to use 2 (Europe's timezone)
+			int mTimezone = 1;						///<  Property: 'timezone' set to use 2 (Europe's timezone)
     };
 
 
@@ -71,25 +71,34 @@ namespace nap
 		void update(double deltaTime) override;
 
 		/**
-		 * @brief Checks whether the sun is currently above the horizon.
-		 * @return bool `true` if the sun is up (daytime), `false` if down (nighttime).
-		 */
-		bool isUp() const								{ return mState == EState::Up; }
-
-		/**
 		 * @return current sun state (up or down)
 		 */
 		EState getState() const							{ return mState; }
 
 		/**
-		 * @return sunset time for current day
+		 * @return local sunset time
 		 */
 		const DateTime& getSunSet() const				{ return mSunset; }
 
 		/**
-		 * @return sunrise time for current day
+		 * @return local sunrise time
 		 */
 		const DateTime& getSunRise() const				{ return mSunRise; }
+
+		/**
+		 * @return latitude
+		 */
+		double getLatitude() const						{ return mLatitude; }
+
+		/**
+		 * @return longitude
+		 */
+		double getLongitude() const						{ return mLongitude; }
+
+		/**
+		 * @return bool `true` if the sun is up (daytime), `false` if down (nighttime).
+		 */
+		bool isUp() const								{ return mState == EState::Up; }
 
 		/**
 		 * Listen to this signal to get notified on sunset / sunrise
@@ -111,11 +120,9 @@ namespace nap
 		std::unique_ptr<SunSet> mModel;					///< unique ptr to the sunset class
 		EDay mDay = EDay::Unknown;						///< current day
 
-		double mSunRiseMinute = 0;						///< Minutes past midnight for sunrise
 		SystemTimeStamp mSunRiseStamp;					///< Sunrise timestamp
 		DateTime mSunRise;								///< Sunrise date-time
 
-		double mSunSetMinute =  0;						///< Minutes past midnight for sunset
 		SystemTimeStamp mSunSetStamp;					///< Sunset timestamp
 		DateTime mSunset;								///< Sunset date-time
 

--- a/src/sunsetcalculatorcomponent.h
+++ b/src/sunsetcalculatorcomponent.h
@@ -96,6 +96,16 @@ namespace nap
 		 */
 		Signal<EState> mSunStateChanged;
 
+		/**
+		 * Listen to this signal to get notified of sunrise
+		 */
+		Signal<> mSunUp;
+
+		/**
+		 * Listen to this signal to get notifief of sunset
+		 */
+		Signal<> mSunDown;
+
 	private:
 		EState mState = EState::Unknown;				///< Current daylight status (true = sun is above horizon)
 		std::unique_ptr<SunSet> mModel;					///< unique ptr to the sunset class


### PR DESCRIPTION
Simplifies and fixes sunset calculation by computing and comparing timestamps using chrono. The local sunset and sunrise  is calculated when the day changes. Events are triggered by comparing the current local time to the computed (local) sun up and down time. 

Note that this change removes the delta, which could be calculated by storing and comparing sunset and sunrise timestamps.